### PR TITLE
Fix wrong attribute of ion-loading snippet

### DIFF
--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -170,7 +170,7 @@
         "body": [
             "async ${1:presentLoading}() {",
             "\tconst ${2:loading} = await this.${3:loadingController}.create({",
-            "\t\tcontent: '${4:Hellooo}',",
+            "\t\tmessage: '${4:Hellooo}',",
             "\t\tduration: ${5:2000}",
             "\t});",
             "\tawait ${2:loading}.present();",


### PR DESCRIPTION
According the current v4 document, the parameter of `LoadingControll.create()` should have `message` attribute, not `content`